### PR TITLE
fix: adding sns attributes [AIRSK-617]

### DIFF
--- a/src/aws/sns-publisher.ts
+++ b/src/aws/sns-publisher.ts
@@ -1,17 +1,37 @@
 import { SNSManagementNotificationSettings } from './sns-management-notification-settings';
 import { Publisher } from '../publisher';
 import { PublishedNotification } from '../notification';
+import { SNS as SNSClass } from 'aws-sdk';
+import { packageInfo } from '../package-info';
 
 export class SNSPublisher implements Publisher {
 	constructor(private config: SNSManagementNotificationSettings) {}
 
 	async publish(notification: PublishedNotification) {
 		const { SNS } = require('aws-sdk');
-		const sns = new SNS({ region: this.config.snsRegion });
+		const sns: SNSClass = new SNS({ region: this.config.snsRegion });
 		await sns
 			.publish({
 				Message: JSON.stringify(notification),
 				TopicArn: this.config.snsTopicArn,
+				MessageAttributes: {
+					applicationName: {
+						DataType: 'String',
+						StringValue: this.config.applicationName || packageInfo.name,
+					},
+					applicationVersion: {
+						DataType: 'String',
+						StringValue: this.config.applicationVersion || packageInfo.version,
+					},
+					defaultTags: {
+						DataType: 'String.Array',
+						StringValue: JSON.stringify(this.config.defaultTags || []),
+					},
+					tags: {
+						DataType: 'String.Array',
+						StringValue: JSON.stringify(notification.tags || []),
+					},
+				},
 			})
 			.promise();
 	}

--- a/test/unit/aws/sns-publiser.spec.ts
+++ b/test/unit/aws/sns-publiser.spec.ts
@@ -1,3 +1,4 @@
+import { packageInfo } from './../../../src/package-info';
 const SNS = jest.fn();
 jest.mock('aws-sdk', () => ({ SNS }));
 import { SNSManagementNotificationSettings } from './../../../src/aws/sns-management-notification-settings';
@@ -32,6 +33,63 @@ describe(SNSPublisher.name, () => {
 				{
 					Message: '{"info":"my notification"}',
 					TopicArn: 'sns topic arn',
+					MessageAttributes: {
+						applicationName: {
+							DataType: 'String',
+							StringValue: packageInfo.name,
+						},
+						applicationVersion: {
+							DataType: 'String',
+							StringValue: packageInfo.version,
+						},
+						defaultTags: {
+							DataType: 'String.Array',
+							StringValue: '[]',
+						},
+						tags: {
+							DataType: 'String.Array',
+							StringValue: '[]',
+						},
+					},
+				},
+			]);
+			expect(promise).toHaveCallsLike([]);
+			expect(result).toBeUndefined();
+		});
+
+		it('should return an instance of ManagementNotificationClient with a SQS Publisher instance when there is specified name, version default tags and tags', async () => {
+			config.applicationName = 'my app';
+			config.applicationVersion = 'my version';
+			config.defaultTags = ['my default tags'];
+
+			const result = await target.publish({
+				info: 'my notification',
+				tags: ['my tags'],
+			} as any);
+
+			expect(SNS).toHaveCallsLike([{ region: 'sns region' }]);
+			expect(publish).toHaveCallsLike([
+				{
+					Message: '{"info":"my notification","tags":["my tags"]}',
+					TopicArn: 'sns topic arn',
+					MessageAttributes: {
+						applicationName: {
+							DataType: 'String',
+							StringValue: 'my app',
+						},
+						applicationVersion: {
+							DataType: 'String',
+							StringValue: 'my version',
+						},
+						defaultTags: {
+							DataType: 'String.Array',
+							StringValue: '["my default tags"]',
+						},
+						tags: {
+							DataType: 'String.Array',
+							StringValue: '["my tags"]',
+						},
+					},
 				},
 			]);
 			expect(promise).toHaveCallsLike([]);


### PR DESCRIPTION
message attributes can help to create filters to lambda triggers, which can help to make application-specific lambdas if needed, keeping the cost as low as possible